### PR TITLE
only run crucible-ci on pull_requests

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -1,9 +1,7 @@
 name: crucible-ci
 
 on:
-  # run on push or pull request events for the main branch only
-  push:
-    branches: [ main ]
+  # run on pull request events for the main branch only
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
- when running on pushes into the master branch is enabled,
  crucible-ci will run when developer's forks are updated