### PR TITLE
switch network test mv-params to use 'default-route' instead of a nam…

### DIFF
--- a/.github/actions/integration-tests/mv-params/iperf-1.json
+++ b/.github/actions/integration-tests/mv-params/iperf-1.json
@@ -7,7 +7,7 @@
 		{ "arg": "protocol", "vals": [ "tcp" ] },
 		{ "arg": "bitrate", "vals": [ "0" ] },
 
-		{ "arg": "ifname", "vals" : [ "eth0" ], "role": "server" }
+		{ "arg": "ifname", "vals" : [ "default-route" ], "role": "server" }
 	    ]
 	}
     ],

--- a/.github/actions/integration-tests/mv-params/iperf-2.json
+++ b/.github/actions/integration-tests/mv-params/iperf-2.json
@@ -7,7 +7,7 @@
 		{ "arg": "protocol", "vals": [ "udp" ] },
 		{ "arg": "bitrate", "vals": [ "0" ] },
 
-		{ "arg": "ifname", "vals" : [ "eth0" ], "role": "server" }
+		{ "arg": "ifname", "vals" : [ "default-route" ], "role": "server" }
 	    ]
 	}
     ],

--- a/.github/actions/integration-tests/mv-params/uperf-1.json
+++ b/.github/actions/integration-tests/mv-params/uperf-1.json
@@ -8,7 +8,7 @@
 		{ "arg": "rsize", "vals": [ "64" ], "role": "client" },
 		{ "arg": "duration", "vals": [ "10" ], "role": "client" },
 
-		{ "arg": "ifname", "vals" : [ "eth0" ], "role": "server" }
+		{ "arg": "ifname", "vals" : [ "default-route" ], "role": "server" }
 	    ]
 	}
     ],

--- a/.github/actions/integration-tests/mv-params/uperf-2.json
+++ b/.github/actions/integration-tests/mv-params/uperf-2.json
@@ -8,7 +8,7 @@
 		{ "arg": "rsize", "vals": [ "64" ], "role": "client" },
 		{ "arg": "duration", "vals": [ "10" ], "role": "client" },
 
-		{ "arg": "ifname", "vals" : [ "eth0" ], "role": "server" }
+		{ "arg": "ifname", "vals" : [ "default-route" ], "role": "server" }
 	    ]
 	}
     ],


### PR DESCRIPTION
…ed interface

- this makes the CI tests compatible with a wider range of test
  environments without modifications being required