### PR TITLE
add service start/stop testing near the beginning of testing

### DIFF
--- a/.github/actions/integration-tests/run-ci-stage1
+++ b/.github/actions/integration-tests/run-ci-stage1
@@ -302,6 +302,15 @@ run_cmd "crucible help"
 
 run_cmd "crucible repo info"
 
+for action in start stop; do
+    for service in httpd es redis; do
+        run_cmd "podman ps --all --external"
+
+        run_cmd "crucible ${action} ${service}"
+    done
+done
+run_cmd "podman ps --all --external"
+
 # some endpoints (such as k8s) will require a "remote" address for the
 # controller to allow connectivity from separate network namespaces
 # (ie. a pod); provide this by determining which device is used for


### PR DESCRIPTION
- individually test the ability to start and stop each service

- do it early because subsequent testing will most likely fail if
  these fail, but it may take much longer if we allow the traditional
  automated start of the services to be the only way they are tested