### PR TITLE
updates for faux-crucible-ci

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -6,6 +6,7 @@ on:
     paths-ignore:
     - LICENSE
     - '**.md'
+    - .github/workflows/faux-crucible-ci.yaml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/faux-crucible-ci.yaml
+++ b/.github/workflows/faux-crucible-ci.yaml
@@ -1,4 +1,4 @@
-name: crucible-ci
+name: faux-crucible-ci
 
 on:
   pull_request:
@@ -6,6 +6,7 @@ on:
     paths:
     - LICENSE
     - '**.md'
+    - .github/workflows/faux-crucible-ci.yaml
 
 jobs:
   crucible-ci-complete:


### PR DESCRIPTION
- change the name to make it easier to distinguish between crucible-ci and faux-crucible-ci in the GitHub interface -- it appears this does not matter since the gating job name stays the same between them (crucible-ci-complete)

- add the faux-crucible-ci.yaml file to the list of files to ignore/operate on -- there is no need to run crucible-ci when changes are made to faux-crucible-ci