### PR TITLE
Remove passthru from cmdline if all-in-one json

### DIFF
--- a/.github/actions/integration-tests/run-ci-stage1
+++ b/.github/actions/integration-tests/run-ci-stage1
@@ -412,7 +412,7 @@ for userenv in ${CI_ACTIVE_USERENVS}; do
                     sed -i "s|SCRIPT_DIR|${SCRIPT_DIR}|g" ${SCRIPT_DIR}/run-file/oslat.json
                     sed -i "s|COMMON_ENDPOINT_ARGS|${COMMON_ENDPOINT_ARGS}|g" ${SCRIPT_DIR}/run-file/oslat.json
                     sed -i "s|COMMON_K8S_ENDPOINT_ARGS|${COMMON_K8S_ENDPOINT_ARGS}|g" ${SCRIPT_DIR}/run-file/oslat.json
-                    run_cmd "crucible run oslat --num-samples ${CI_SAMPLES} --test-order s --from-file ${SCRIPT_DIR}/run-file/oslat.json"
+                    run_cmd "crucible run oslat --from-file ${SCRIPT_DIR}/run-file/oslat.json"
                     post_run_cmd
                 else
                     # mv-params param mode

--- a/.github/actions/integration-tests/run-file/oslat.json
+++ b/.github/actions/integration-tests/run-file/oslat.json
@@ -23,5 +23,5 @@
             ]
         }
     ],
-    "passthru-args": " --tags run:single-jsonTAGS --endpoint k8s,COMMON_ENDPOINT_ARGS,COMMON_K8S_ENDPOINT_ARGS,client:1-2,server:1,cpu-partitioning:default:1,securityContext:client-1:SCRIPT_DIR/k8s-endpoint/securityContext-oslat.json,securityContext:client-2:SCRIPT_DIR/k8s-endpoint/securityContext-oslat.json"
+    "passthru-args": " --num-samples 1 --test-order s --tags run:single-jsonTAGS --endpoint k8s,COMMON_ENDPOINT_ARGS,COMMON_K8S_ENDPOINT_ARGS,client:1-2,server:1,cpu-partitioning:default:1,securityContext:client-1:SCRIPT_DIR/k8s-endpoint/securityContext-oslat.json,securityContext:client-2:SCRIPT_DIR/k8s-endpoint/securityContext-oslat.json"
 }


### PR DESCRIPTION
Another fix in crucible is needed to prevent user defining passthru from cmdline and all-in-one json at the same time. This makes args processing difficult and confusing as they are processed out of order.