### PR TITLE
add reasonable job timeouts to the reusable workflows

### DIFF
--- a/.github/workflows/benchmark-crucible-ci.yaml
+++ b/.github/workflows/benchmark-crucible-ci.yaml
@@ -32,6 +32,7 @@ env:
 jobs:
   gen-params:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       userenvs: ${{ steps.get-userenvs.outputs.userenvs }}
       github_hosted_scenarios: ${{ steps.get-scenarios-github.outputs.scenarios }}
@@ -84,6 +85,7 @@ jobs:
 
   display-params:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: gen-params
     steps:
     - name: Echo gen-params outputs
@@ -91,6 +93,7 @@ jobs:
 
   github-runners:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     needs:
     - gen-params
     - display-params
@@ -149,6 +152,7 @@ jobs:
 
   self-hosted-runners:
     runs-on: [ self-hosted, cpu-partitioning, remotehost ]
+    timeout-minutes: 90
     needs:
     - gen-params
     - display-params
@@ -207,6 +211,7 @@ jobs:
 
   benchmark-crucible-ci-complete:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs:
     - github-runners
     - self-hosted-runners

--- a/.github/workflows/core-crucible-ci.yaml
+++ b/.github/workflows/core-crucible-ci.yaml
@@ -37,6 +37,7 @@ env:
 jobs:
   gen-params:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       userenvs: ${{ steps.get-userenvs.outputs.userenvs }}
       build_controller: ${{ steps.check-controller-build.outputs.build-controller }}
@@ -154,6 +155,7 @@ jobs:
 
   display-params:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: gen-params
     steps:
     - name: Echo gen-params outputs
@@ -161,6 +163,7 @@ jobs:
 
   build-controller:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs:
     - gen-params
     - display-params
@@ -224,6 +227,7 @@ jobs:
 
   github-runners:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     needs:
     - gen-params
     - display-params
@@ -288,6 +292,7 @@ jobs:
 
   self-hosted-runners:
     runs-on: [ self-hosted, cpu-partitioning, remotehost ]
+    timeout-minutes: 90
     needs:
     - gen-params
     - display-params
@@ -352,6 +357,7 @@ jobs:
 
   core-crucible-ci-complete:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs:
     - github-runners
     - self-hosted-runners

--- a/.github/workflows/tool-crucible-ci.yaml
+++ b/.github/workflows/tool-crucible-ci.yaml
@@ -32,6 +32,7 @@ env:
 jobs:
   gen-params:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       userenvs: ${{ steps.get-userenvs.outputs.userenvs }}
       github_hosted_scenarios: ${{ steps.get-scenarios-github.outputs.scenarios }}
@@ -76,6 +77,7 @@ jobs:
 
   display-params:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: gen-params
     steps:
     - name: Echo gen-params outputs
@@ -83,6 +85,7 @@ jobs:
 
   github-runners:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     needs:
     - gen-params
     - display-params
@@ -141,6 +144,7 @@ jobs:
 
   tool-crucible-ci-complete:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs:
     - github-runners
     steps:


### PR DESCRIPTION
- prevent jobs that hang from running until the very long default timeout (360 minutes)