### PR TITLE
Remove benchmark from all-in-one cli

### DIFF
--- a/.github/actions/integration-tests/run-ci-stage1
+++ b/.github/actions/integration-tests/run-ci-stage1
@@ -444,7 +444,7 @@ for userenv in ${CI_ACTIVE_USERENVS}; do
                     sed -i "s|CONTROLLER_IP|${CONTROLLER_IP}|g" ${RUN_FILE}
                     sed -i "s|CI_ENDPOINT_HOST|${CI_ENDPOINT_HOST}|g" ${RUN_FILE}
                     sed -i "s|CI_ENDPOINT_USER|${CI_ENDPOINT_USER}|g" ${RUN_FILE}
-                    run_cmd "crucible run oslat --from-file ${RUN_FILE}"
+                    run_cmd "crucible run --from-file ${RUN_FILE}"
                     post_run_cmd
                 fi
                 ;;


### PR DESCRIPTION
Instead of crucible run oslat --from-file <json>, it must be:

Using all-in-one json:
crucible run --from-file <json>

or

Backwards compatibility mode:
crucible run oslat --mv-params {...}