### PR TITLE
ignore symbolic links when getting the list of userenvs in the get-us…

### DIFF
--- a/.github/actions/get-userenvs/generate-userenv-list.sh
+++ b/.github/actions/get-userenvs/generate-userenv-list.sh
@@ -6,7 +6,7 @@ rickshaw_directory=${1}
 excludes="stream8-flexran"
 
 if pushd ${rickshaw_directory}; then
-    userenvs=$(find userenvs/ -maxdepth 1 -name '*.json' | sed -e 's|userenvs/||' -e 's|\.json||')
+    userenvs=$(find userenvs/ -maxdepth 1 -name '*.json' -type f | sed -e 's|userenvs/||' -e 's|\.json||')
     # Discard excluded envs
     for ex in ${excludes[@]}; do
         new=( "${userenvs[@]/$ex}" )


### PR DESCRIPTION
…erenvs action

- this allows for the creation of userenv aliases without increasing the CI runtime