### PR TITLE
create the infrastructure for a caller of core-crucible-ci to be able…

### DIFF
--- a/.github/actions/install-crucible/action.yml
+++ b/.github/actions/install-crucible/action.yml
@@ -21,8 +21,12 @@ inputs:
     description: "A controller tag to pull from the ci controller repository"
     required: false
     default: "none"
+  force_engine_build:
+    description: "Force the building of engine containers"
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
-    - run: sudo ${{ github.action_path }}/install-crucible.sh --run-environment github --ci-target ${{ inputs.ci_target }} --ci-target-dir ${{ inputs.ci_target_dir }} --ci-endpoint ${{ inputs.ci_endpoint }} --ci-controller ${{ inputs.ci_controller }} --controller-tag ${{ inputs.controller_tag }}
+    - run: sudo ${{ github.action_path }}/install-crucible.sh --run-environment github --ci-target ${{ inputs.ci_target }} --ci-target-dir ${{ inputs.ci_target_dir }} --ci-endpoint ${{ inputs.ci_endpoint }} --ci-controller ${{ inputs.ci_controller }} --controller-tag ${{ inputs.controller_tag }} --force-engine-build ${{ inputs.force_engine_build }}
       shell: bash

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -41,6 +41,10 @@ inputs:
     description: "A controller tag to pull from the ci controller repository"
     required: false
     default: "none"
+  force_engine_build:
+    description: "Force the building of engine containers"
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -50,7 +54,7 @@ runs:
     - run: ${{ github.action_path }}/ci-environment-info --run-environment github
       shell: bash
 
-    - run: sudo ${{ github.action_path }}/../install-crucible/install-crucible.sh --run-environment github --ci-target ${{ inputs.ci_target }} --ci-target-dir ${{ inputs.ci_target_dir }} --ci-endpoint ${{ inputs.ci_endpoint }} --ci-controller ${{ inputs.ci_controller }} --controller-tag ${{ inputs.controller_tag }}
+    - run: sudo ${{ github.action_path }}/../install-crucible/install-crucible.sh --run-environment github --ci-target ${{ inputs.ci_target }} --ci-target-dir ${{ inputs.ci_target_dir }} --ci-endpoint ${{ inputs.ci_endpoint }} --ci-controller ${{ inputs.ci_controller }} --controller-tag ${{ inputs.controller_tag }} --force-engine-build ${{ inputs.force_engine_build }}
       shell: bash
 
     - run: sudo ${{ github.action_path }}/setup-ci-endpoint --run-environment github --ci-endpoint ${{ inputs.ci_endpoint }}

--- a/.github/workflows/core-crucible-ci.yaml
+++ b/.github/workflows/core-crucible-ci.yaml
@@ -23,6 +23,10 @@ on:
       github_workspace:
         required: true
         type: string
+      force_engine_build:
+        required: false
+        type: string
+        default: "false"
     secrets:
       registry_auth:
         required: false
@@ -302,6 +306,7 @@ jobs:
         ci_target_dir: ${{ github.workspace }}/${{ needs.gen-params.outputs.ci_target_dir }}
         ci_controller: ${{ matrix.ci_controller }}
         controller_tag: ${{ needs.gen-params.outputs.repo_name }}_${{ inputs.ci_target }}_${{ github.run_number }}
+        force_engine_build: "${{ inputs.force_engine_build }}"
     - name: skip crucible-ci->integration-tests
       if: ${{ ! matrix.scenario.enabled }}
       run: echo "crucible-ci->integration-tests not enabled"
@@ -373,6 +378,7 @@ jobs:
         ci_target_dir: ${{ github.workspace }}/${{ needs.gen-params.outputs.ci_target_dir }}
         ci_controller: ${{ matrix.ci_controller }}
         controller_tag: ${{ needs.gen-params.outputs.repo_name }}_${{ inputs.ci_target }}_${{ github.run_number }}
+        force_engine_build: "${{ inputs.force_engine_build }}"
     - name: skip crucible-ci->integration-tests
       if: ${{ ! matrix.scenario.enabled }}
       run: echo "crucible-ci->integration-tests not enabled"


### PR DESCRIPTION
… to force all engine container images to be built

- when "force_engine_build == true" then all engine container images will be built without checking whether they already exist or not

- this will allow a future CI job to "refresh" the production engine container images that are built via the "if merged" PR process