### PR TITLE
allow the timeout-minutes of the integration-test jobs to be modified…

### DIFF
--- a/.github/workflows/core-crucible-ci.yaml
+++ b/.github/workflows/core-crucible-ci.yaml
@@ -27,6 +27,10 @@ on:
         required: false
         type: string
         default: "false"
+      integration_test_job_timeout:
+        required: false
+        type: number
+        default: 90
     secrets:
       registry_auth:
         required: false
@@ -241,7 +245,7 @@ jobs:
 
   github-runners:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: ${{ inputs.integration_test_job_timeout }}
     needs:
     - gen-params
     - display-params
@@ -313,7 +317,7 @@ jobs:
 
   self-hosted-runners:
     runs-on: [ self-hosted, cpu-partitioning, remotehost, remotehosts ]
-    timeout-minutes: 90
+    timeout-minutes: ${{ inputs.integration_test_job_timeout }}
     needs:
     - gen-params
     - display-params


### PR DESCRIPTION
… in the core-crucible-ci reusable workflow

- it appears that the 90 minute timeout is insufficient if force_engine_build is enabled