### PR TITLE
add 'rhel-ai' to the list of excluded userenvs

### DIFF
--- a/.github/actions/get-userenvs/generate-userenv-list.sh
+++ b/.github/actions/get-userenvs/generate-userenv-list.sh
@@ -3,7 +3,7 @@
 # vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
 
 rickshaw_directory=${1}
-excludes="stream8-flexran"
+excludes="stream8-flexran rhel-ai"
 
 if pushd ${rickshaw_directory}; then
     userenvs=$(find userenvs/ -maxdepth 1 -name '*.json' -type f | sed -e 's|userenvs/||' -e 's|\.json||')


### PR DESCRIPTION
- The 'rhel-ai' userenv is specifically for RHEL-AI testing and is not meant for general purpose usage and as such does not need to be applied to all the crucible-ci test cases