### PR TITLE
move all "overhead" jobs to dedicated "workflow-overhead" self-hosted…

### DIFF
--- a/.github/workflows/benchmark-crucible-ci.yaml
+++ b/.github/workflows/benchmark-crucible-ci.yaml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   gen-params:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     timeout-minutes: 10
     outputs:
       userenvs: ${{ steps.get-userenvs.outputs.userenvs }}
@@ -90,7 +90,7 @@ jobs:
       uses: ./crucible-ci/.github/actions/get-repo-name
 
   display-params:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     timeout-minutes: 10
     needs: gen-params
     steps:
@@ -242,7 +242,7 @@ jobs:
       run: echo "crucible-ci->integration-tests not enabled"
 
   benchmark-crucible-ci-complete:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     timeout-minutes: 10
     needs:
     - github-runners

--- a/.github/workflows/core-crucible-ci.yaml
+++ b/.github/workflows/core-crucible-ci.yaml
@@ -42,7 +42,7 @@ env:
 
 jobs:
   gen-params:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     timeout-minutes: 10
     outputs:
       userenvs: ${{ steps.get-userenvs.outputs.userenvs }}
@@ -160,7 +160,7 @@ jobs:
         fi
 
   display-params:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     timeout-minutes: 10
     needs: gen-params
     steps:
@@ -398,7 +398,7 @@ jobs:
       run: echo "crucible-ci->integration-tests not enabled"
 
   core-crucible-ci-complete:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     timeout-minutes: 10
     needs:
     - github-runners

--- a/.github/workflows/faux-benchmark-crucible-ci.yaml
+++ b/.github/workflows/faux-benchmark-crucible-ci.yaml
@@ -5,6 +5,6 @@ on:
 
 jobs:
   benchmark-crucible-ci-complete:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     steps:
     - run: 'echo "faux-benchmark-crucible-ci-complete"'

--- a/.github/workflows/faux-core-crucible-ci.yaml
+++ b/.github/workflows/faux-core-crucible-ci.yaml
@@ -5,6 +5,6 @@ on:
 
 jobs:
   core-crucible-ci-complete:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     steps:
     - run: 'echo "faux-core-crucible-ci-complete"'

--- a/.github/workflows/faux-crucible-ci.yaml
+++ b/.github/workflows/faux-crucible-ci.yaml
@@ -14,17 +14,17 @@ on:
 
 jobs:
   test-benchmark-crucible-ci-complete:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     steps:
     - run: 'echo "No build required" '
 
   test-core-crucible-ci-complete:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     steps:
     - run: 'echo "No build required" '
 
   test-tool-crucible-ci-complete:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     steps:
     - run: 'echo "No build required" '
 

--- a/.github/workflows/faux-tool-crucible-ci.yaml
+++ b/.github/workflows/faux-tool-crucible-ci.yaml
@@ -5,6 +5,6 @@ on:
 
 jobs:
   tool-crucible-ci-complete:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     steps:
     - run: 'echo "faux-tool-crucible-ci-complete"'

--- a/.github/workflows/test-benchmark-crucible-ci.yaml
+++ b/.github/workflows/test-benchmark-crucible-ci.yaml
@@ -37,7 +37,7 @@ jobs:
       quay_oauth_token: ${{ secrets.CRUCIBLE_QUAYIO_OAUTH_TOKEN }}
 
   test-benchmark-crucible-ci-complete:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     needs: call-benchmark-crucible-ci
     steps:
     - name: Confirm Success

--- a/.github/workflows/test-core-crucible-ci.yaml
+++ b/.github/workflows/test-core-crucible-ci.yaml
@@ -38,7 +38,7 @@ jobs:
       quay_oauth_token: ${{ secrets.CRUCIBLE_QUAYIO_OAUTH_TOKEN }}
 
   test-core-crucible-ci-complete:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     needs: call-core-crucible-ci
     steps:
     - name: Confirm Success

--- a/.github/workflows/test-tool-crucible-ci.yaml
+++ b/.github/workflows/test-tool-crucible-ci.yaml
@@ -35,7 +35,7 @@ jobs:
       quay_oauth_token: ${{ secrets.CRUCIBLE_QUAYIO_OAUTH_TOKEN }}
 
   test-tool-crucible-ci-complete:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     needs: call-tool-crucible-ci
     steps:
     - name: Confirm Success

--- a/.github/workflows/tool-crucible-ci.yaml
+++ b/.github/workflows/tool-crucible-ci.yaml
@@ -37,7 +37,7 @@ env:
 
 jobs:
   gen-params:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     timeout-minutes: 10
     outputs:
       userenvs: ${{ steps.get-userenvs.outputs.userenvs }}
@@ -82,7 +82,7 @@ jobs:
       uses: ./crucible-ci/.github/actions/get-repo-name
 
   display-params:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     timeout-minutes: 10
     needs: gen-params
     steps:
@@ -162,7 +162,7 @@ jobs:
       run: echo "crucible-ci->integration-tests not enabled"
 
   tool-crucible-ci-complete:
-    runs-on: ubuntu-latest
+    runs-on: [ self-hosted, workflow-overhead ]
     timeout-minutes: 10
     needs:
     - github-runners


### PR DESCRIPTION
… runners to reduce contention

- the integration test jobs will continue to run on the existing set of GitHub + self-hosted containers

- the dedicated "workflow-overhead" self-hosted runners will only process the "overhead" jobs and will hopefully allow smoother execution of the workflows when there is large amounts of contention