### PR TITLE
add 30 minutes to the timeout of the runner jobs for the core-crucibl…

### DIFF
--- a/.github/workflows/core-crucible-ci.yaml
+++ b/.github/workflows/core-crucible-ci.yaml
@@ -260,7 +260,7 @@ jobs:
 
   github-runners:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     needs:
     - gen-params
     - display-params
@@ -337,7 +337,7 @@ jobs:
 
   self-hosted-runners:
     runs-on: [ self-hosted, cpu-partitioning, remotehost, remotehosts ]
-    timeout-minutes: 90
+    timeout-minutes: 120
     needs:
     - gen-params
     - display-params


### PR DESCRIPTION
…e-ci workflow

- when a controller image is built and force-builds is enabled (for the first run only) the jobs just take longer and need some extra headroom

- since this is tied to a controller build it is only applicable to the core-crucible-ci workflow