### PR TITLE
make sure that /lib/firmware exists

### DIFF
--- a/.github/actions/install-crucible/install-crucible.sh
+++ b/.github/actions/install-crucible/install-crucible.sh
@@ -131,6 +131,10 @@ start_github_group "Create /etc/sysconfig"
 mkdir -pv /etc/sysconfig
 stop_github_group
 
+start_github_group "Making sure /lib/firmware exists"
+mkdir -pv /lib/firmware
+stop_github_group
+
 start_github_group "Install Crucible"
 if pushd ~/ > /dev/null; then
     INSTALLER_PATH="./crucible-install.sh"


### PR DESCRIPTION
- the endpoints map this directory into the engines and it is starting to not appear in all environments