### PR TITLE
add workshop to the special cases for CI_TARGET in the install-crucib…

### DIFF
--- a/.github/actions/install-crucible/install-crucible.sh
+++ b/.github/actions/install-crucible/install-crucible.sh
@@ -266,11 +266,11 @@ else
     if [ "${RELEASE_TAG}" != "upstream" ]; then
         if [ "${CI_TARGET}" == "crucible" ]; then
             echo "INFO: When a release tag is specified and crucible is the CI target, only the installer script is used from the PR/upstream code"
-        else
-            if [ "${CI_TARGET}" != "none" ]; then
-                echo "ERROR: It does not make sense to set a release tag and CI target (unless set to Crucible to test installer changes) since the CI target would override the release tag"
-                exit 1
-            fi
+        elif [ "${CI_TARGET}" == "workshop" ]; then
+            echo "INFO: When a release tag is specified and workshop is the CI target, the PR/upstream code was used to build an experimental controller image that is being tested against a release in it's entirety (no experimental workshop code present)."
+        elif [ "${CI_TARGET}" != "none" ]; then
+            echo "ERROR: It does not make sense to set a release tag and CI target (unless set to Crucible to test installer changes) since the CI target would override the release tag"
+            exit 1
         fi
     else
         if [ "${CI_TARGET}" != "none" ]; then


### PR DESCRIPTION
…le action

- When workshop is being tested as the CI_TARGET, it will be used to build an experimental controller image that is then tested against the existing Crucible releases.  Since those releases will have a specific version of Workshop already it is not necessary to plug the PR/upstream code for Workshop into that installation.