### PR TITLE
set an explicit comment on the ssh key created by the integration-tes…

### DIFF
--- a/.github/actions/integration-tests/setup-ci-endpoint
+++ b/.github/actions/integration-tests/setup-ci-endpoint
@@ -51,7 +51,7 @@ validate_ci_endpoint
 start_github_group "Configure loop SSH access"
 apt install openssh-server
 systemctl start sshd
-ssh-keygen -t ed25519 -q -f /root/.ssh/id_ed25519 -N ""
+ssh-keygen -t ed25519 -q -f /root/.ssh/id_ed25519 -N "" -C "crucible-ci-loopback"
 bash -c "cat /root/.ssh/id_ed25519.pub > /root/.ssh/authorized_keys"
 chmod 600 /root/.ssh/authorized_keys
 if ! do_ssh -o StrictHostKeyChecking=no localhost echo "password-less root login over ssh works"; then


### PR DESCRIPTION
…ts action

- this ensures that it is not confused with the keys that the engines used to use to connect back to the controller