### PR TITLE
Add kmr-cloud-1 label to self-hosted runners

### DIFF
--- a/.github/workflows/benchmark-crucible-ci.yaml
+++ b/.github/workflows/benchmark-crucible-ci.yaml
@@ -188,7 +188,7 @@ jobs:
       run: echo "crucible-ci->integration-tests not enabled"
 
   self-hosted-runners:
-    runs-on: [ self-hosted, cpu-partitioning, remotehosts ]
+    runs-on: [ self-hosted, kmr-cloud-1, cpu-partitioning, remotehosts ]
     timeout-minutes: 90
     needs:
     - gen-params

--- a/.github/workflows/core-crucible-ci.yaml
+++ b/.github/workflows/core-crucible-ci.yaml
@@ -327,7 +327,7 @@ jobs:
       run: echo "crucible-ci->integration-tests not enabled"
 
   self-hosted-runners:
-    runs-on: [ self-hosted, cpu-partitioning, remotehosts ]
+    runs-on: [ self-hosted, kmr-cloud-1, cpu-partitioning, remotehosts ]
     timeout-minutes: ${{ fromJSON(needs.gen-params.outputs.timeout_minutes) }}
     needs:
     - gen-params


### PR DESCRIPTION
## Summary

This PR adds the `kmr-cloud-1` label to self-hosted runner declarations to distinguish KMR cloud runners from other potential runner pools (e.g., AWS cloud).

## Changes

Modified the `runs-on` directive in two workflows:
- `.github/workflows/core-crucible-ci.yaml`
- `.github/workflows/benchmark-crucible-ci.yaml`

**Before:**
```yaml
runs-on: [ self-hosted, cpu-partitioning, remotehosts ]
```

**After:**
```yaml
runs-on: [ self-hosted, kmr-cloud-1, cpu-partitioning, remotehosts ]
```

## Prerequisites

**IMPORTANT:** KMR cloud self-hosted runners must be configured with the `kmr-cloud-1` label before merging this PR, otherwise workflows will fail to find available runners.

Runner label configuration needed:
```
self-hosted, kmr-cloud-1, cpu-partitioning, remotehosts, workflow-overhead
```

## Rationale

This change allows us to:
1. Explicitly target KMR cloud runners
2. Distinguish KMR runners from future AWS cloud runners
3. Provide foundation for future multi-cloud runner support

## Scope

This is a **minimal, static label change** only. It does not include:
- Dynamic runner pool selection
- Workflow input parameters for pool selection
- Changes to rickshaw or other repos

The full dynamic implementation is tracked in PR #192.

## Testing

Once KMR runners are labeled with `kmr-cloud-1`:
- Workflows will continue to run on KMR cloud runners
- No functional changes to workflow behavior
- Only the runner targeting becomes more explicit