### PR TITLE
Add dynamic runner pool support for flexible self-hosted runner selection

### DIFF
--- a/.github/actions/get-job-parameters/action.yml
+++ b/.github/actions/get-job-parameters/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: "Comma separated list of tags the runner has"
     required: false
     default: ""
+  runner-pool:
+    description: "Which pool of self-hosted runners to use (e.g., 'kmr-cloud-1', 'aws-cloud-1')"
+    required: false
+    default: ""
   benchmark:
     description: "Which benchmark to restrict the scenarios to"
     required: false
@@ -32,4 +36,4 @@ runs:
     - name: "Generate jobs list"
       id: generate-jobs
       shell: bash
-      run: TOOLBOX_HOME=${{ inputs.toolbox-directory }} ${{ inputs.rickshaw-directory }}/util/generate-ci-jobs.py --runner-type "${{ inputs.runner-type }}" --runner-tags "${{ inputs.runner-tags }}" --userenv-filter "${{ inputs.userenv-filter }}" --runtime-env "github" --benchmark "${{ inputs.benchmark }}"
+      run: TOOLBOX_HOME=${{ inputs.toolbox-directory }} ${{ inputs.rickshaw-directory }}/util/generate-ci-jobs.py --runner-type "${{ inputs.runner-type }}" --runner-tags "${{ inputs.runner-tags }}" --runner-pool "${{ inputs.runner-pool }}" --userenv-filter "${{ inputs.userenv-filter }}" --runtime-env "github" --benchmark "${{ inputs.benchmark }}"

--- a/.github/workflows/benchmark-crucible-ci.yaml
+++ b/.github/workflows/benchmark-crucible-ci.yaml
@@ -22,6 +22,10 @@ on:
         required: false
         type: string
         default: "all"
+      runner_pool:
+        required: false
+        type: string
+        default: "kmr-cloud-1"
     secrets:
       registry_auth:
         required: false
@@ -92,6 +96,7 @@ jobs:
         runner-type: "self-hosted"
         userenv-filter: ${{ inputs.userenv_filter }}
         runner-tags: "cpu-partitioning,remotehosts"
+        runner-pool: ${{ inputs.runner_pool }}
         benchmark: "${{ inputs.ci_target }}"
         rickshaw-directory: "./rickshaw"
         toolbox-directory: "./toolbox"
@@ -188,7 +193,7 @@ jobs:
       run: echo "crucible-ci->integration-tests not enabled"
 
   self-hosted-runners:
-    runs-on: [ self-hosted, kmr-cloud-1, cpu-partitioning, remotehosts ]
+    runs-on: ${{ fromJSON(toJSON(matrix.job.runner_labels)) }}
     timeout-minutes: 90
     needs:
     - gen-params

--- a/.github/workflows/core-crucible-ci.yaml
+++ b/.github/workflows/core-crucible-ci.yaml
@@ -43,6 +43,10 @@ on:
         required: false
         type: string
         default: "no"
+      runner_pool:
+        required: false
+        type: string
+        default: "kmr-cloud-1"
     secrets:
       registry_auth:
         required: false
@@ -199,6 +203,7 @@ jobs:
       with:
         runner-type: "self-hosted"
         runner-tags: "cpu-partitioning,remotehosts"
+        runner-pool: ${{ inputs.runner_pool }}
         userenv-filter: ${{ inputs.userenv_filter }}
         rickshaw-directory: "./rickshaw"
         toolbox-directory: "./toolbox"
@@ -327,7 +332,7 @@ jobs:
       run: echo "crucible-ci->integration-tests not enabled"
 
   self-hosted-runners:
-    runs-on: [ self-hosted, kmr-cloud-1, cpu-partitioning, remotehosts ]
+    runs-on: ${{ fromJSON(toJSON(matrix.job.runner_labels)) }}
     timeout-minutes: ${{ fromJSON(needs.gen-params.outputs.timeout_minutes) }}
     needs:
     - gen-params

--- a/RUNNER_POOL_IMPLEMENTATION.md
+++ b/RUNNER_POOL_IMPLEMENTATION.md
@@ -1,0 +1,205 @@
+# Runner Pool Implementation Guide
+
+## Overview
+
+This implementation allows you to switch between different pools of self-hosted GitHub Actions runners (e.g., KMR cloud vs AWS cloud) by simply changing a workflow input parameter, without modifying rickshaw or any other core components.
+
+## Architecture
+
+The runner pool selection flows through three layers:
+
+1. **Workflow Input** → Specify which pool to use (e.g., "kmr-cloud-1" or "aws-cloud-1")
+2. **generate-ci-jobs.py** → Builds runner label list dynamically
+3. **runs-on Directive** → Uses dynamic labels from job matrix
+
+## Files Modified
+
+### In rickshaw (PR #757)
+- `util/generate-ci-jobs.py` - Added `--runner-pool` parameter and `runner_labels` field to jobs
+
+### In crucible-ci
+- `.github/actions/get-job-parameters/action.yml` - Added `runner-pool` input
+- `.github/workflows/core-crucible-ci.yaml` - Added `runner_pool` input and dynamic `runs-on`
+- `.github/workflows/benchmark-crucible-ci.yaml` - Added `runner_pool` input and dynamic `runs-on`
+
+## How to Use
+
+### Default Behavior (KMR Cloud Runners)
+
+No changes needed! The default is set to "kmr-cloud-1":
+
+```yaml
+# workflows automatically use:
+runner_pool: "kmr-cloud-1"  # This is the default
+```
+
+Jobs will run on runners labeled: `["self-hosted", "kmr-cloud-1", "cpu-partitioning", "remotehosts"]`
+
+### Switching to AWS Cloud Runners
+
+When calling a workflow, override the `runner_pool` input:
+
+```yaml
+# In your calling workflow:
+jobs:
+  test:
+    uses: ./.github/workflows/core-crucible-ci.yaml
+    with:
+      runner_pool: "aws-cloud-1"
+      # ... other inputs
+```
+
+Jobs will run on runners labeled: `["self-hosted", "aws-cloud-1", "cpu-partitioning", "remotehosts"]`
+
+### Switching Back to Default (No Pool Label)
+
+To use runners without a pool-specific label:
+
+```yaml
+jobs:
+  test:
+    uses: ./.github/workflows/core-crucible-ci.yaml
+    with:
+      runner_pool: ""  # Empty string = no pool label
+      # ... other inputs
+```
+
+Jobs will run on runners labeled: `["self-hosted", "cpu-partitioning", "remotehosts"]`
+
+## Runner Configuration
+
+### KMR Cloud Runners
+
+Configure your runners with these labels:
+```
+self-hosted, kmr-cloud-1, cpu-partitioning, remotehosts, workflow-overhead
+```
+
+### AWS Cloud Runners
+
+Configure your runners with these labels:
+```
+self-hosted, aws-cloud-1, cpu-partitioning, remotehosts, workflow-overhead
+```
+
+### Important Notes
+
+1. **Both pools can run simultaneously** - The labels distinguish which jobs go to which pool
+2. **All capability labels must be present** - Both pools need `cpu-partitioning`, `remotehosts`, etc.
+3. **The pool label is inserted second** - Order: `["self-hosted", "<pool>", "<other-tags>"]`
+
+## Testing Strategy
+
+### Phase 1: Test Rickshaw Changes (In Progress)
+- PR #757 tests backward compatibility
+- Existing workflows run without changes
+- Verify `runner_labels` field is generated correctly
+
+### Phase 2: Test Crucible-CI Changes
+1. Push this branch to your fork
+2. Create a test workflow that calls core-crucible-ci with `runner_pool: "kmr-cloud-1"`
+3. Verify jobs target the correct runners
+4. Test switching to `runner_pool: "aws-cloud-1"`
+5. Verify jobs switch to AWS runners
+
+### Phase 3: Production Rollout
+1. Merge rickshaw PR #757
+2. Merge this crucible-ci PR
+3. Configure AWS runners with `aws-cloud-1` label
+4. Test in a non-critical workflow
+5. Roll out to production workflows
+
+## Troubleshooting
+
+### Jobs Don't Run
+**Problem:** Jobs are queued but never start
+
+**Possible Causes:**
+1. No runners have the pool label (e.g., no runner labeled `aws-cloud-1`)
+2. Runners don't have all required labels (missing `cpu-partitioning` or `remotehosts`)
+
+**Solution:** Check runner labels match exactly what's in `runner_labels` field
+
+### Wrong Runners Execute Jobs
+**Problem:** Jobs run on KMR runners when expecting AWS
+
+**Possible Causes:**
+1. `runner_pool` input not passed correctly
+2. Default value is being used instead of specified value
+
+**Solution:** Check workflow call includes `runner_pool: "aws-cloud-1"`
+
+### Syntax Errors in runs-on
+**Problem:** Workflow fails with syntax error on `runs-on` line
+
+**Possible Causes:**
+1. Rickshaw PR #757 not merged (no `runner_labels` field in jobs)
+2. JSON parsing issue with `fromJSON(toJSON(...))`
+
+**Solution:** Verify rickshaw has been updated with PR #757 changes
+
+## Examples
+
+### Example 1: Temporary AWS Testing
+
+Test a PR on AWS runners:
+
+```yaml
+name: PR Test on AWS
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test-on-aws:
+    uses: ./.github/workflows/core-crucible-ci.yaml
+    with:
+      ci_target: "crucible"
+      ci_target_branch: ${{ github.head_ref }}
+      github_workspace: ${{ github.workspace }}
+      runner_pool: "aws-cloud-1"  # Force AWS for this test
+```
+
+### Example 2: Matrix Testing Both Pools
+
+Test on both pools to compare results:
+
+```yaml
+jobs:
+  test-both-pools:
+    strategy:
+      matrix:
+        pool: ["kmr-cloud-1", "aws-cloud-1"]
+    uses: ./.github/workflows/core-crucible-ci.yaml
+    with:
+      runner_pool: ${{ matrix.pool }}
+      # ... other inputs
+```
+
+### Example 3: Default Production Workflow
+
+No changes needed - uses KMR by default:
+
+```yaml
+jobs:
+  production-test:
+    uses: ./.github/workflows/core-crucible-ci.yaml
+    with:
+      ci_target: "crucible"
+      # runner_pool defaults to "kmr-cloud-1"
+```
+
+## Future Enhancements
+
+Possible future improvements:
+
+1. **Auto-selection based on load** - Automatically pick less busy pool
+2. **Cost tracking** - Tag jobs with pool info for cost analysis
+3. **Geographic selection** - `us-east-cloud-1` vs `us-west-cloud-1`
+4. **Fallback pools** - Try AWS if KMR is full
+5. **Runner pool health checks** - Warn if no runners available for a pool
+
+## Related Documentation
+
+- Rickshaw PR: https://github.com/perftool-incubator/rickshaw/pull/757
+- Rickshaw changes: ../rickshaw/RUNNER_POOL_CHANGES.md


### PR DESCRIPTION
## Summary

This PR adds dynamic runner pool support, enabling workflows to switch between different pools of self-hosted runners (e.g., KMR cloud vs AWS cloud) by changing a workflow input parameter.

**Builds on:** PR #193 (merged) which added the static `kmr-cloud-1` label

## Dependencies

**Requires:** Rickshaw runner pool support ✅ **MERGED** to all active branches:
- master: PR #758 ✅ Merged
- 2025.2: PR #761 ✅ Merged
- 2025.3: PR #762 ✅ Merged  
- 2025.4: PR #763 ✅ Merged
- 2026.1: PR #764 ✅ Merged

All rickshaw branches now support the `--runner-pool` parameter.

## Changes

### 1. get-job-parameters Action
- Added `runner-pool` input (optional, default: "")
- Passes `--runner-pool` to `generate-ci-jobs.py`

### 2. Workflow Files (core-crucible-ci, benchmark-crucible-ci)
- Added `runner_pool` workflow input (default: "kmr-cloud-1")
- Changed `runs-on` from static `[ self-hosted, kmr-cloud-1, cpu-partitioning, remotehosts ]` to dynamic `${{ fromJSON(toJSON(matrix.job.runner_labels)) }}`
- Pass `runner_pool` to get-job-parameters action

### 3. Documentation
- Added `RUNNER_POOL_IMPLEMENTATION.md` with complete usage guide

## How It Works

### Label Flow
1. Workflow specifies `runner_pool: "kmr-cloud-1"` (or "aws-cloud-1")
2. get-job-parameters passes it to rickshaw's `generate-ci-jobs.py`
3. Rickshaw generates jobs with `runner_labels: ["self-hosted", "kmr-cloud-1", "cpu-partitioning", "remotehosts"]`
4. `runs-on` directive uses these labels dynamically from the job matrix

### Usage Examples

**Default (KMR Cloud):**
```yaml
uses: ./.github/workflows/core-crucible-ci.yaml
with:
  # runner_pool defaults to "kmr-cloud-1"
  ci_target: "crucible"
```

**Switch to AWS Cloud:**
```yaml
uses: ./.github/workflows/core-crucible-ci.yaml
with:
  runner_pool: "aws-cloud-1"
  ci_target: "crucible"
```

**No Pool Label (backward compatible):**
```yaml
uses: ./.github/workflows/core-crucible-ci.yaml
with:
  runner_pool: ""
  ci_target: "crucible"
```

## What This PR Does NOT Include

- ❌ No `/var/lib/crucible` path changes
- ❌ No deleted jobs or removed tests
- ❌ No backward compatibility code (all rickshaw branches now support `--runner-pool`)
- ❌ No changes beyond runner pool implementation

This is a **focused, minimal implementation** of just the dynamic runner pool feature.

## Testing

The implementation leverages:
- ✅ Rickshaw PRs merged to all active branches (2025.2+, 2026.1, master)
- ✅ PR #193 (merged) - KMR runners labeled with `kmr-cloud-1`

Testing will verify:
1. Default behavior (kmr-cloud-1) works with current runners
2. Jobs successfully use dynamic `runner_labels` from matrix
3. Pool can be switched via workflow input parameter
4. Works across all rickshaw release branches

## Benefits

1. **No rickshaw changes needed** when switching pools - control from crucible-ci
2. **Both pools can run simultaneously** - isolated by labels
3. **Easy A/B testing** - run same workflow on different pools
4. **Future-proof** - can add more pools (GCP, Azure, etc.) without code changes

## Documentation

See `RUNNER_POOL_IMPLEMENTATION.md` for complete documentation, usage examples, and troubleshooting guide.