### PR TITLE
fix: use GitHub-hosted runner for project tracking

### DIFF
--- a/.github/workflows/crucible-tracking.yaml
+++ b/.github/workflows/crucible-tracking.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   project-tracking:
-    runs-on: [ self-hosted, project-tracker ]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
 


### PR DESCRIPTION
## Summary
- Switch the `project-tracking` job in `crucible-tracking.yaml` from `[ self-hosted, project-tracker ]` to `ubuntu-latest`
- This job only uses `gh api graphql` and `jq` — no self-hosted runner capabilities are needed

## Test plan
- [ ] Verify the workflow triggers correctly on PR/issue events
- [ ] Confirm project tracking fields are set properly on the GitHub project board

🤖 Generated with [Claude Code](https://claude.com/claude-code)