### PR TITLE
fix: only set status on tracked items when no status exists

### DIFF
--- a/.github/workflows/crucible-tracking.yaml
+++ b/.github/workflows/crucible-tracking.yaml
@@ -74,6 +74,25 @@ jobs:
             }' -f project=$PROJECT_ID -f item=$ITEM_ID --jq '.data.addProjectV2ItemById.item.id')"
           echo 'ITEM_ID='$item_id >> $GITHUB_ENV
 
+      - name: Get current status
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          current_status="$(gh api graphql -f query='
+            query($item: ID!) {
+              node(id: $item) {
+                ... on ProjectV2Item {
+                  fieldValueByName(name: "Status") {
+                    ... on ProjectV2ItemFieldSingleSelectValue {
+                      name
+                    }
+                  }
+                }
+              }
+            }' -f item=$ITEM_ID --jq '.data.node.fieldValueByName.name // empty')"
+          echo "Current status: '${current_status}'"
+          echo "CURRENT_STATUS=${current_status}" >> $GITHUB_ENV
+
       - name: Get date
         run: echo "DATE=$(date -u +"%Y-%m-%d")" >> $GITHUB_ENV
 
@@ -82,37 +101,46 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           STATUS_OPTION_ID: ${{ github.event.pull_request && env.IN_PROGRESS_OPTION_ID || env.QUEUED_OPTION_ID }}
         run: |
-          gh api graphql -f query='
+          # Only set status if the item does not already have one
+          status_mutation=""
+          if [ -z "${CURRENT_STATUS}" ]; then
+            echo "No current status set, setting to requested value"
+            status_mutation='set_status: updateProjectV2ItemFieldValue(input: {
+              projectId: $project
+              itemId: $item
+              fieldId: $status_field
+              value: {
+                singleSelectOptionId: $status_value
+              }
+            }) {
+              projectV2Item {
+                id
+              }
+            }'
+          else
+            echo "Status already set to '${CURRENT_STATUS}', not overriding"
+          fi
+
+          gh api graphql -f query="
             mutation (
-              $project: ID!
-              $item: ID!
-              $status_field: ID!
-              $status_value: String!
-              $date_field: ID!
-              $date_value: Date!
+              \$project: ID!
+              \$item: ID!
+              \$status_field: ID!
+              \$status_value: String!
+              \$date_field: ID!
+              \$date_value: Date!
             ) {
-              set_status: updateProjectV2ItemFieldValue(input: {
-                projectId: $project
-                itemId: $item
-                fieldId: $status_field
-                value: {
-                  singleSelectOptionId: $status_value
-                  }
-              }) {
-                projectV2Item {
-                  id
-                  }
-              }
+              ${status_mutation}
               set_date_posted: updateProjectV2ItemFieldValue(input: {
-                projectId: $project
-                itemId: $item
-                fieldId: $date_field
+                projectId: \$project
+                itemId: \$item
+                fieldId: \$date_field
                 value: {
-                  date: $date_value
+                  date: \$date_value
                 }
               }) {
                 projectV2Item {
                   id
                 }
               }
-            }' -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=${{ env.STATUS_OPTION_ID }} -f date_field=$DATE_FIELD_ID -f date_value=$DATE --silent
+            }" -f project=$PROJECT_ID -f item=$ITEM_ID -f status_field=$STATUS_FIELD_ID -f status_value=${{ env.STATUS_OPTION_ID }} -f date_field=$DATE_FIELD_ID -f date_value=$DATE --silent


### PR DESCRIPTION
## Summary

The crucible-tracking workflow was unconditionally setting the status field when adding items to the project, overriding any status that was already set (e.g., resetting "In Progress" back to "Queued" on issues). Now it queries the current status first and only sets it if the item has no status yet.

## Test plan

- [ ] Verify new issues get status set to "Queued"
- [ ] Verify new PRs get status set to "In Progress"
- [ ] Verify items with an existing status are not overridden

🤖 Generated with [Claude Code](https://claude.com/claude-code)