### PR TITLE
feat: add release name to core CI job names

### DIFF
--- a/.github/workflows/core-crucible-ci.yaml
+++ b/.github/workflows/core-crucible-ci.yaml
@@ -63,6 +63,7 @@ env:
 
 jobs:
   gen-endpoints:
+    name: gen-endpoints(${{ inputs.release }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -146,6 +147,7 @@ jobs:
         fi
 
   display-endpoints:
+    name: display-endpoints(${{ inputs.release }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: gen-endpoints

--- a/.github/workflows/core-endpoint-crucible-ci.yaml
+++ b/.github/workflows/core-endpoint-crucible-ci.yaml
@@ -70,7 +70,7 @@ env:
 
 jobs:
   gen-params:
-    name: gen-params(${{ inputs.endpoint }})
+    name: gen-params(${{ inputs.release }}, ${{ inputs.endpoint }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -159,7 +159,7 @@ jobs:
         toolbox-directory: "./toolbox"
 
   display-params:
-    name: display-params(${{ inputs.endpoint }})
+    name: display-params(${{ inputs.release }}, ${{ inputs.endpoint }})
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: gen-params

--- a/.github/workflows/test-benchmark-crucible-ci.yaml
+++ b/.github/workflows/test-benchmark-crucible-ci.yaml
@@ -32,6 +32,7 @@ jobs:
             .github/workflows/test-tool-crucible-ci.yaml
             .github/workflows/core-crucible-ci.yaml
             .github/workflows/core-release-crucible-ci.yaml
+            .github/workflows/core-endpoint-crucible-ci.yaml
             .github/workflows/tool-crucible-ci.yaml
             .github/actions/build-controller/**
             .github/actions/check-controller-build/**

--- a/.github/workflows/test-core-crucible-ci.yaml
+++ b/.github/workflows/test-core-crucible-ci.yaml
@@ -31,6 +31,7 @@ jobs:
             .github/workflows/test-benchmark-crucible-ci.yaml
             .github/workflows/test-tool-crucible-ci.yaml
             .github/workflows/benchmark-crucible-ci.yaml
+            .github/workflows/endpoint-crucible-ci.yaml
             .github/workflows/tool-crucible-ci.yaml
             docs/**
       - name: Display changes

--- a/.github/workflows/test-tool-crucible-ci.yaml
+++ b/.github/workflows/test-tool-crucible-ci.yaml
@@ -32,6 +32,7 @@ jobs:
             .github/workflows/test-benchmark-crucible-ci.yaml
             .github/workflows/core-crucible-ci.yaml
             .github/workflows/core-release-crucible-ci.yaml
+            .github/workflows/core-endpoint-crucible-ci.yaml
             .github/workflows/benchmark-crucible-ci.yaml
             .github/actions/build-controller/**
             .github/actions/check-controller-build/**


### PR DESCRIPTION
## Summary

Add release context to job display names in the GitHub UI for core CI workflows:
- `gen-endpoints` → `gen-endpoints(2026.1)`
- `display-endpoints` → `display-endpoints(2026.1)`
- `gen-params(kube)` → `gen-params(2026.1, kube)`
- `display-params(kube)` → `display-params(2026.1, kube)`

Makes it easier to follow workflow execution when core-release-crucible-ci runs multiple releases in parallel.

## Test plan

- [ ] Verify job names display correctly in GitHub UI with release context

🤖 Generated with [Claude Code](https://claude.com/claude-code)