### PR TITLE
fix: allow any ci_target with release tag when controller was rebuilt

### DIFF
--- a/.github/actions/install-crucible/install-crucible.sh
+++ b/.github/actions/install-crucible/install-crucible.sh
@@ -291,6 +291,8 @@ else
             echo "INFO: When a release tag is specified and crucible is the CI target, only the installer script is used from the PR/upstream code"
         elif [ "${CI_TARGET}" == "workshop" ]; then
             echo "INFO: When a release tag is specified and workshop is the CI target, the PR/upstream code was used to build an experimental controller image that is being tested against a release in it's entirety (no experimental workshop code present)."
+        elif [ "${CI_CONTROLLER}" == "yes" ]; then
+            echo "INFO: When a release tag is specified and a controller was built, the CI target '${CI_TARGET}' contributed requirements to the experimental controller image that is being tested against a release in its entirety (no experimental ${CI_TARGET} code present)."
         elif [ "${CI_TARGET}" != "none" ]; then
             echo "ERROR: It does not make sense to set a release tag and CI target (unless set to Crucible to test installer changes) since the CI target would override the release tag"
             exit 1


### PR DESCRIPTION
## Summary
- Fix `install-crucible.sh` to allow any `ci_target` with a release tag when a controller image was rebuilt (`CI_CONTROLLER=yes`)
- Previously only `crucible` and `workshop` were allowed as ci_targets with release tags, causing all release test jobs to fail for subprojects like roadblock, toolbox, etc. that now have `workshop.json` files contributing to the controller build
- The ci_target code is never overridden on releases (guarded by `RELEASE_TAG == upstream` on line 238), so the restriction was overly strict

## Context
This is needed for the workshop.json decentralization effort where core subprojects declare their own controller image requirements. When a subproject's `workshop.json` changes, the controller is rebuilt and tested against all releases — but `install-crucible.sh` was rejecting the combination.

## Test plan
- [ ] CI passes
- [ ] Re-run roadblock PR #83 CI after merge — release jobs should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)