### PR TITLE
fix: update check-controller-build for renamed files and precise matching

### DIFF
--- a/.github/actions/check-controller-build/check-controller-build.sh
+++ b/.github/actions/check-controller-build/check-controller-build.sh
@@ -48,7 +48,7 @@ else
             fi
             echo
 
-            workshop_files_changed=$(${diff_cmd} | grep "^workshop/" | wc -l)
+            workshop_files_changed=$(${diff_cmd} | grep -E "^workshop/(controller-workshop\.json|crucible-controller-requirements\.json|fedora\.json|crucible-controller-userenv\.json|build-controller\.sh|controller\.conf|controller\.json|controller-image\.py)" | wc -l)
             echo "workshop_files_changed=${workshop_files_changed}"
             echo
 

--- a/.github/actions/check-controller-build/validate-inputs.sh
+++ b/.github/actions/check-controller-build/validate-inputs.sh
@@ -71,7 +71,8 @@ else
         error "Could not pushd to the crucible directory '${crucible_directory}'"
     else
         echo "Contents of crucible workshop directory:"
-        if [ -f crucible-install.sh -a -d workshop -a -f workshop/build-controller.sh -a -f workshop/controller-workshop.json ]; then
+        if [ -f crucible-install.sh -a -d workshop -a -f workshop/build-controller.sh ] && \
+           [ -f workshop/controller-workshop.json -o -f workshop/crucible-controller-requirements.json ]; then
             ls -l workshop/
         else
             ls -l


### PR DESCRIPTION
## Summary
- Update `validate-inputs.sh` to accept both `controller-workshop.json` (old) and `crucible-controller-requirements.json` (new) for backwards compatibility across releases
- Update `check-controller-build.sh` to match only files that affect the controller image contents instead of all files under `workshop/`, preventing unnecessary rebuilds from README or script-only changes

## Test plan
- [ ] CI passes
- [ ] Changes to `workshop/README.md` no longer trigger controller rebuilds
- [ ] Changes to `workshop/crucible-controller-requirements.json` still trigger controller rebuilds

🤖 Generated with [Claude Code](https://claude.com/claude-code)