### PR TITLE
feat: update build-controller action and remove dead code

### DIFF
--- a/.github/actions/build-controller/build-controller.sh
+++ b/.github/actions/build-controller/build-controller.sh
@@ -48,7 +48,7 @@ while true; do
     esac
 done
 
-run_cmd "crucible wrapper /opt/crucible/workshop/build-controller.sh --config /opt/crucible/subprojects/core/crucible-ci/actions/build-controller/files/ci-config.json"
+run_cmd "crucible wrapper /opt/crucible/workshop/controller-image.py build --config /opt/crucible/subprojects/core/crucible-ci/actions/build-controller/files/ci-config.json"
 
 run_and_capture_cmd "podman images"
 podman_images="${captured_output}"

--- a/.github/actions/check-controller-build/check-controller-build.sh
+++ b/.github/actions/check-controller-build/check-controller-build.sh
@@ -100,8 +100,6 @@ else
 
     if [ "${ci_target_directory}" == "${crucible_directory}" -o "./${ci_target_directory}" == "${crucible_directory}" ]; then
         echo "CI target is Crucible -> no analysis required"
-    elif [ "${ci_target_directory}" == "${workshop_directory}" -o "./${ci_target_directory}" == "${workshop_directory}" ]; then
-        echo "CI target is Workshop -> no analysis required"
     else
         echo "CI target directory is '${ci_target_directory}'"
         echo "Conducting CI target change analysis:"

--- a/.github/actions/common-code/common-code.sh
+++ b/.github/actions/common-code/common-code.sh
@@ -43,18 +43,6 @@ function log_rc {
     fi
 }
 
-function validate_ci_build_controller {
-    case "${CI_BUILD_CONTROLLER}" in
-        yes|no)
-            echo "CI Build Controller is '${CI_BUILD_CONTROLLER}'"
-            echo
-            ;;
-        *)
-            echo "ERROR: Unknown CI_BUILD_CONTROLLER value [${CI_BUILD_CONTROLLER}]"
-            exit 1
-            ;;
-    esac
-}
 
 function validate_ci_run_environment {
     case "${CI_RUN_ENVIRONMENT}" in

--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -25,10 +25,6 @@ inputs:
     description: "Which rickshaw endpoint to exercise"
     required: false
     default: "remotehosts"
-  ci_build_controller:
-    description: "Should the crucible controller be rebuilt and tested"
-    required: false
-    default: "no"
   ci_param_mode:
     description: "Should crucible use --mv-params or --from-file (single json)"
     required: false
@@ -64,7 +60,7 @@ runs:
     - run: sudo ${{ github.action_path }}/setup-ci-endpoint --run-environment github --ci-endpoint ${{ inputs.ci_endpoint }}
       shell: bash
 
-    - run: sudo ${{ github.action_path }}/run-ci-stage1 --run-environment github --scenarios ${{ inputs.scenarios }} --userenvs ${{ inputs.userenvs }} --ci-endpoint ${{ inputs.ci_endpoint }} --ci-build-controller ${{ inputs.ci_build_controller }} --ci-param-mode ${{ inputs.ci_param_mode }} --ci-release ${{ inputs.crucible_release }}
+    - run: sudo ${{ github.action_path }}/run-ci-stage1 --run-environment github --scenarios ${{ inputs.scenarios }} --userenvs ${{ inputs.userenvs }} --ci-endpoint ${{ inputs.ci_endpoint }} --ci-param-mode ${{ inputs.ci_param_mode }} --ci-release ${{ inputs.crucible_release }}
       shell: bash
 
     - uses: actions/upload-artifact@v4

--- a/.github/actions/integration-tests/run-ci-stage1
+++ b/.github/actions/integration-tests/run-ci-stage1
@@ -59,13 +59,11 @@ CI_ENDPOINT_USER="root"
 
 CI_RUN_UPDATE="yes"
 
-CI_BUILD_CONTROLLER="no"
-
 CI_PARAM_MODE="all"
 
 CI_RELEASE="upstream"
 
-longopts="verbose,scenarios:,userenvs:,samples:,repeat-runs:,run-environment:,ci-endpoint:,ci-endpoint-host:,ci-endpoint-user:,ci-build-controller:"
+longopts="verbose,scenarios:,userenvs:,samples:,repeat-runs:,run-environment:,ci-endpoint:,ci-endpoint-host:,ci-endpoint-user:"
 longopts+=",ci-param-mode:,disable-update-test,ci-release:"
 opts=$(getopt -q -o "" --longoptions "${longopts}" -n "$0" -- "$@")
 if [ ${?} -ne 0 ]; then
@@ -83,11 +81,6 @@ while true; do
         --ci-param-mode)
             shift
             CI_PARAM_MODE="${1}"
-            shift
-            ;;
-        --ci-build-controller)
-            shift
-            CI_BUILD_CONTROLLER="${1}"
             shift
             ;;
         --disable-update-test)
@@ -153,7 +146,6 @@ done
 # validate inputs
 validate_ci_run_environment
 validate_ci_endpoint
-validate_ci_build_controller
 
 for scenario in $(echo "${CI_SCENARIOS}" | sed -e "s/,/ /g"); do
     case "${scenario}" in
@@ -439,34 +431,6 @@ function remove_k8s_images {
             ;;
     esac
 }
-
-if [ "${CI_BUILD_CONTROLLER}" == "yes" ]; then
-    run_cmd "crucible wrapper /opt/crucible/workshop/build-controller.sh"
-
-    run_and_capture_cmd "podman images"
-    podman_images="${captured_output}"
-
-    if [ ${RC_STATUS} == 0 -a -n "${podman_images}" ]; then
-        header="Identifying New Crucible Controller Image"
-        start_github_group "${header}"
-        echo "${header}"
-        echo
-
-        controller_image_line=$(echo "${podman_images}" | grep crucible-controller)
-
-        if [ -n "${controller_image_line}" ]; then
-            controller_image=$(echo "${controller_image_line}" | awk '{ print $1":"$2 }')
-            echo "New controller image name: ${controller_image}"
-        else
-            echo "ERROR: Failed to isolate new Crucible controller image"
-            RC_STATUS=1
-        fi
-
-        stop_github_group
-    fi
-
-    run_cmd "sed -i -e s#^\(CRUCIBLE_CONTAINER_IMAGE=\).*#\1${controller_image}# /etc/sysconfig/crucible"
-fi
 
 run_cmd "cat /etc/sysconfig/crucible"
 


### PR DESCRIPTION
## Summary
- Call `controller-image.py build` directly instead of the shell wrapper in the build-controller action
- Remove workshop special case from `check-controller-build` — workshop now has its own `workshop.json` like other subprojects
- Remove dead `CI_BUILD_CONTROLLER` code from integration tests — never triggered (no workflow sets it to "yes"), superseded by the `build-controller` job in `core-release-crucible-ci`

## Dependencies
- crucible#545 (merged) — adds `controller-image.py`

## Test plan
- [ ] CI passes
- [ ] Controller image builds successfully via `controller-image.py build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)