### PR TITLE
feat: block fork PRs and skip CI for fork-originated pull requests

### DIFF
--- a/.github/workflows/fork-check.yaml
+++ b/.github/workflows/fork-check.yaml
@@ -1,0 +1,27 @@
+name: fork-check
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  block-fork-pr:
+    if: github.event.pull_request.head.repo.fork == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment and close fork PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'This PR was opened from a fork. PRs must be opened from branches on the upstream repository so that CI workflows have access to required secrets and variables.\n\nPlease push your branch to this repository and open a new PR.\n\nClosing this PR automatically.'
+            });
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              state: 'closed'
+            });

--- a/.github/workflows/test-benchmark-crucible-ci.yaml
+++ b/.github/workflows/test-benchmark-crucible-ci.yaml
@@ -27,6 +27,7 @@ jobs:
             .github/runners/**
             .github/workflows/faux-*.yaml
             .github/workflows/run-crucible-tracking.yaml
+            .github/workflows/fork-check.yaml
             .github/workflows/crucible-tracking.yaml
             .github/workflows/test-core-crucible-ci.yaml
             .github/workflows/test-tool-crucible-ci.yaml
@@ -44,7 +45,7 @@ jobs:
 
   call-benchmark-crucible-ci:
     needs: changes
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true') }}
     strategy:
       fail-fast: false
       matrix:
@@ -72,7 +73,7 @@ jobs:
 
   faux-test-benchmark-crucible-ci:
     needs: changes
-    if: ${{ github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - run: echo "faux-test-benchmark-crucible-ci-complete"

--- a/.github/workflows/test-core-crucible-ci.yaml
+++ b/.github/workflows/test-core-crucible-ci.yaml
@@ -27,6 +27,7 @@ jobs:
             .github/runners/**
             .github/workflows/faux-*.yaml
             .github/workflows/run-crucible-tracking.yaml
+            .github/workflows/fork-check.yaml
             .github/workflows/crucible-tracking.yaml
             .github/workflows/test-benchmark-crucible-ci.yaml
             .github/workflows/test-tool-crucible-ci.yaml
@@ -39,7 +40,7 @@ jobs:
 
   call-core-crucible-ci:
     needs: changes
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true') }}
     strategy:
       fail-fast: false
       matrix:
@@ -63,7 +64,7 @@ jobs:
 
   call-core-release-crucible-ci:
     needs: changes
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true') }}
     strategy:
       fail-fast: false
       matrix:
@@ -94,7 +95,7 @@ jobs:
 
   faux-test-core-crucible-ci:
     needs: changes
-    if: ${{ github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - run: echo "faux-test-core-crucible-ci-complete"

--- a/.github/workflows/test-tool-crucible-ci.yaml
+++ b/.github/workflows/test-tool-crucible-ci.yaml
@@ -27,6 +27,7 @@ jobs:
             .github/runners/**
             .github/workflows/faux-*.yaml
             .github/workflows/run-crucible-tracking.yaml
+            .github/workflows/fork-check.yaml
             .github/workflows/crucible-tracking.yaml
             .github/workflows/test-core-crucible-ci.yaml
             .github/workflows/test-benchmark-crucible-ci.yaml
@@ -44,7 +45,7 @@ jobs:
 
   call-tool-crucible-ci:
     needs: changes
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true') }}
     strategy:
       fail-fast: false
       matrix:
@@ -69,7 +70,7 @@ jobs:
 
   faux-test-tool-crucible-ci:
     needs: changes
-    if: ${{ github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - run: echo "faux-test-tool-crucible-ci-complete"


### PR DESCRIPTION
## Summary
- Add `fork-check.yaml` workflow that automatically comments and closes PRs from forks
- Add fork guard to test-benchmark, test-core, and test-tool CI workflows
- Add `fork-check.yaml` to CI exclusion lists

Part of an org-wide rollout across all repos.

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)