### PR TITLE
feat: update service tests and strip \r from captured output

### DIFF
--- a/.github/actions/common-code/common-code.sh
+++ b/.github/actions/common-code/common-code.sh
@@ -148,7 +148,7 @@ function run_and_capture_cmd {
         start_github_group "${header}"
         echo "${header}"
         echo
-        captured_output=$(${cmd} | sed -e "/^\*\*\* NOTICE/d" -e "/^$/d")
+        captured_output=$(${cmd} | tr -d '\r' | sed -e "/^\*\*\* NOTICE/d" -e "/^$/d")
         rc=${?}
         echo "captured_output:"
         echo ">>>>>"

--- a/.github/actions/integration-tests/run-ci-stage1
+++ b/.github/actions/integration-tests/run-ci-stage1
@@ -464,14 +464,33 @@ case "${CI_RELEASE}" in
         ;;
 esac
 
-for action in start stop; do
-    for service in httpd opensearch redis; do
+case "${CI_RELEASE}" in
+    "2024.4"|"2025.1"|"2025.2"|"2025.3"|"2025.4"|"2026.1"|"2026.2")
+        for action in start stop; do
+            for service in httpd opensearch redis; do
+                run_cmd "podman ps --all --external"
+
+                run_cmd "crucible ${action} ${service}"
+            done
+        done
+        run_cmd "podman ps --all --external"
+        ;;
+    *)
+        for action in start stop; do
+            for service in httpd opensearch valkey cdm-server image-sourcing; do
+                run_cmd "podman ps --all --external"
+
+                run_cmd "crucible ${action} ${service}"
+            done
+        done
         run_cmd "podman ps --all --external"
 
-        run_cmd "crucible ${action} ${service}"
-    done
-done
-run_cmd "podman ps --all --external"
+        run_cmd "crucible start all"
+        run_cmd "podman ps --all --external"
+        run_cmd "crucible stop all"
+        run_cmd "podman ps --all --external"
+        ;;
+esac
 
 # some endpoints (such as k8s) will require a "remote" address for the
 # controller to allow connectivity from separate network namespaces


### PR DESCRIPTION
## Summary
- Updates service start/stop test loop to include all current services (valkey, cdm-server, image-sourcing) replacing the legacy redis reference
- Adds `crucible start all` / `crucible stop all` testing
- Scoped to upstream release only — older releases use the legacy service list
- Strips `\r` from `run_and_capture_cmd` output to handle logger `\r\n` line endings

## Test plan
- [ ] CI runs on upstream — verify all services start/stop individually and via `all`
- [ ] CI runs on older releases — verify legacy service list is used
- [ ] Verify `run_and_capture_cmd` captures clean values without embedded `\r`

🤖 Generated with [Claude Code](https://claude.com/claude-code)