### PR TITLE
feat: add integration tests for new log viewing features

### DIFF
--- a/.github/actions/integration-tests/run-ci-stage1
+++ b/.github/actions/integration-tests/run-ci-stage1
@@ -814,6 +814,22 @@ case "${CI_RELEASE}" in
         ;;
 esac
 
+case "${CI_RELEASE}" in
+    "2024.4"|"2025.1"|"2025.2"|"2025.3"|"2025.4"|"2026.1"|"2026.2")
+        echo "Skipping new log features since they are not supported on the ${CI_RELEASE} release"
+        ;;
+    *)
+        run_cmd "crucible log help" "force"
+        run_cmd "crucible log sessions" "force"
+        run_cmd "crucible log sessions --format json" "force"
+        run_cmd "crucible log info --json" "force"
+        run_cmd "crucible log view last --tail 10" "force"
+        run_cmd "crucible log view last --stream stdout" "force"
+        run_cmd "crucible log view last --grep crucible" "force"
+        run_cmd "crucible log view --since 1h" "force"
+        ;;
+esac
+
 run_cmd "crucible log info" "force"
 
 run_cmd "crucible log view" "force"


### PR DESCRIPTION
## Summary
- Tests the Python logger's new capabilities added in crucible PR #568
- Exercises: `log help`, `log sessions`, `log sessions --format json`, `log info --json`, `log view last --tail`, `log view last --stream`, `log view last --grep`, `log view --since`
- Scoped to upstream release only — older releases skip with message
- Inserted before the existing `log clear` block so the DB has data to query

## Test plan
- [ ] CI runs on upstream — verify all new log commands pass
- [ ] CI runs on older releases — verify they're skipped with message

🤖 Generated with [Claude Code](https://claude.com/claude-code)