### PR TITLE
feat: remove workshop.pl references from check-controller-build and docs

### DIFF
--- a/.github/actions/check-controller-build/check-controller-build.sh
+++ b/.github/actions/check-controller-build/check-controller-build.sh
@@ -79,7 +79,7 @@ else
             fi
             echo
 
-            workshop_files_changed=$(${diff_cmd} | grep "^workshop.pl\|^workshop.py\|^schema.json" | wc -l)
+            workshop_files_changed=$(${diff_cmd} | grep "^workshop.py\|^schema.json" | wc -l)
             echo "workshop_files_changed=${workshop_files_changed}"
             echo
 

--- a/.github/actions/check-controller-build/validate-inputs.sh
+++ b/.github/actions/check-controller-build/validate-inputs.sh
@@ -92,7 +92,7 @@ else
     else
         echo "Contents of the workshop directory:"
         ls -l
-        if [ ! -f workshop.pl -a ! -f workshop.py ] || [ ! -f schema.json ]; then
+        if [ ! -f workshop.py ] || [ ! -f schema.json ]; then
             error "Could not find required workshop directory contents"
         fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ Crucible-CI is a CI testing harness for the [Crucible](https://github.com/perfto
 - Actions are implemented as shell scripts (bash), invoked via `action.yml`
 - Commit messages use conventional format: `feat:`, `fix:`, etc.
 - The main branch should always be ready for user delivery
-- Workshop files: both `workshop.pl` (Perl) and `workshop.py` (Python) are valid
+- Workshop script is `workshop.py`
 
 ## Development Notes
 


### PR DESCRIPTION
## Summary
- Remove `workshop.pl` from existence check in `validate-inputs.sh` — only `workshop.py` required
- Remove `workshop.pl` from diff grep in `check-controller-build.sh`
- Update CLAUDE.md to reflect workshop.py as the only workshop script

## Test plan
- [ ] Controller build check correctly detects changes to workshop.py
- [ ] Controller build check does not look for workshop.pl

🤖 Generated with [Claude Code](https://claude.com/claude-code)