### PR TITLE
fix: CI workflow fixes for fork-check permissions and only_changed

### DIFF
--- a/.github/workflows/fork-check.yaml
+++ b/.github/workflows/fork-check.yaml
@@ -2,7 +2,11 @@ name: fork-check
 
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   block-fork-pr:

--- a/.github/workflows/test-benchmark-crucible-ci.yaml
+++ b/.github/workflows/test-benchmark-crucible-ci.yaml
@@ -13,7 +13,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      only-docs: ${{ steps.filter.outputs.only_changed }}
+      only-docs: ${{ steps.filter.outputs.only_modified }}
     steps:
       - uses: actions/checkout@v4
       - id: filter

--- a/.github/workflows/test-core-crucible-ci.yaml
+++ b/.github/workflows/test-core-crucible-ci.yaml
@@ -13,7 +13,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      only-docs: ${{ steps.filter.outputs.only_changed }}
+      only-docs: ${{ steps.filter.outputs.only_modified }}
     steps:
       - uses: actions/checkout@v4
       - id: filter

--- a/.github/workflows/test-tool-crucible-ci.yaml
+++ b/.github/workflows/test-tool-crucible-ci.yaml
@@ -13,7 +13,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      only-docs: ${{ steps.filter.outputs.only_changed }}
+      only-docs: ${{ steps.filter.outputs.only_modified }}
     steps:
       - uses: actions/checkout@v4
       - id: filter


### PR DESCRIPTION
## Summary

CI workflow fixes:

1. **fork-check.yaml**: Add `permissions` block (`issues: write`, `pull-requests: write`) and broaden event types to include `synchronize` and `edited`.

2. **only_changed→only_modified**: Switch to `only_modified` which correctly includes deleted files.

## Test plan

- [ ] Fork-check: verified working on bench-trafficgen#106
- [ ] only_modified: verify CI runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)