### PR TITLE
fix: skip opensearch init/rebuild on releases where they were removed

### DIFF
--- a/.github/actions/integration-tests/run-ci-stage1
+++ b/.github/actions/integration-tests/run-ci-stage1
@@ -784,9 +784,16 @@ run_cmd "crucible ls --type tags"
 
 run_cmd "crucible opensearch repair"
 
-run_cmd "crucible opensearch init"
+case "${CI_RELEASE}" in
+    "2024.4"|"2025.1"|"2025.2"|"2025.3")
+        run_cmd "crucible opensearch init"
 
-run_cmd "crucible opensearch rebuild"
+        run_cmd "crucible opensearch rebuild"
+        ;;
+    *)
+        echo "Skipping 'crucible opensearch init/rebuild' since they are not supported on the ${CI_RELEASE} release"
+        ;;
+esac
 
 for scenario in $(echo "${CI_SCENARIOS}" | sed -e "s/,/ /g"); do
     if [ "${scenario}" == "multi" ]; then


### PR DESCRIPTION
## Summary
- Skip `crucible opensearch init` and `crucible opensearch rebuild` CI commands on releases 2025.4+ where these subcommands no longer exist
- These commands were removed in the multi-opensearch commit (669b00f, release 2025.4) but the CI continued to call them. They silently passed because the old `opensearch` block in `bin/_main` had no else clause for unrecognized subcommands
- The instances-to-services merge ([crucible#592](https://github.com/perftool-incubator/crucible/pull/592)) correctly routes unknown subcommands to `manage_opensearch.py` which rejects them, exposing this latent issue

## Test plan
- [ ] Verify crucible#592 CI passes after this fix is merged
- [ ] Verify older release CI (2025.3 and earlier) still runs init/rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)