### PR TITLE
feat: remove deprecated runner-type and runner-tags from CI workflows

### DIFF
--- a/.github/actions/get-endpoints/get-endpoints.py
+++ b/.github/actions/get-endpoints/get-endpoints.py
@@ -38,6 +38,7 @@ def main():
     with open(ci_config_file) as fh:
         config = json.load(fh)
 
+    endpoint_configs = config.get("endpoints", {})
     endpoints = set()
     if config["config"]["enabled"]:
         for benchmark in config["benchmarks"]:
@@ -46,7 +47,9 @@ def main():
                     for scenario in benchmark["scenarios"]:
                         if scenario["enabled"]:
                             for endpoint in scenario["endpoints"]:
-                                endpoints.add(endpoint)
+                                ep_config = endpoint_configs.get(endpoint, {})
+                                if ep_config.get("enabled", True):
+                                    endpoints.add(endpoint)
 
     result = sorted(endpoints)
 

--- a/.github/actions/get-job-parameters/action.yml
+++ b/.github/actions/get-job-parameters/action.yml
@@ -12,14 +12,15 @@ inputs:
     required: false
     default: "all"
   runner-type:
-    description: "What type of CI runner are the jobs for (github or self-hosted)?"
-    required: true
+    description: "Deprecated: ignored when capability-based config is used"
+    required: false
+    default: ""
   runner-tags:
-    description: "Comma separated list of tags the runner has"
+    description: "Deprecated: ignored when capability-based config is used"
     required: false
     default: ""
   runner-pool:
-    description: "Which pool of self-hosted runners to use (e.g., 'kmr-cloud-1', 'aws-cloud-1')"
+    description: "Which runner pool to use (e.g., 'aws-cloud-1')"
     required: false
     default: ""
   benchmark:
@@ -40,4 +41,4 @@ runs:
     - name: "Generate jobs list"
       id: generate-jobs
       shell: bash
-      run: TOOLBOX_HOME=${{ inputs.toolbox-directory }} ${{ inputs.rickshaw-directory }}/util/generate-ci-jobs.py --runner-type "${{ inputs.runner-type }}" --runner-tags "${{ inputs.runner-tags }}" --runner-pool "${{ inputs.runner-pool }}" --userenv-filter "${{ inputs.userenv-filter }}" --runtime-env "github" --benchmark "${{ inputs.benchmark }}" --endpoint "${{ inputs.endpoint }}"
+      run: TOOLBOX_HOME=${{ inputs.toolbox-directory }} ${{ inputs.rickshaw-directory }}/util/generate-ci-jobs.py --runner-pool "${{ inputs.runner-pool }}" --userenv-filter "${{ inputs.userenv-filter }}" --runtime-env "github" --benchmark "${{ inputs.benchmark }}" --endpoint "${{ inputs.endpoint }}"

--- a/.github/workflows/core-endpoint-crucible-ci.yaml
+++ b/.github/workflows/core-endpoint-crucible-ci.yaml
@@ -150,8 +150,6 @@ jobs:
       id: get-job-parameters
       uses: ./crucible-ci/.github/actions/get-job-parameters
       with:
-        runner-type: "github"
-        runner-tags: "k8s,kube,cpu-partitioning,remotehosts"
         runner-pool: ${{ inputs.runner_pool }}
         userenv-filter: ${{ inputs.userenv_filter }}
         endpoint: ${{ inputs.endpoint }}

--- a/.github/workflows/endpoint-crucible-ci.yaml
+++ b/.github/workflows/endpoint-crucible-ci.yaml
@@ -92,8 +92,6 @@ jobs:
       id: get-job-parameters
       uses: ./crucible-ci/.github/actions/get-job-parameters
       with:
-        runner-type: "github"
-        runner-tags: "k8s,kube,cpu-partitioning,remotehosts"
         runner-pool: ${{ inputs.runner_pool }}
         userenv-filter: ${{ inputs.userenv_filter }}
         benchmark: ${{ inputs.benchmark }}


### PR DESCRIPTION
## Summary
- Remove `runner-type` and `runner-tags` parameters from workflow calls to `get-job-parameters` action
- Mark `runner-type` and `runner-tags` inputs as deprecated in the action definition
- Remove `--runner-type` and `--runner-tags` from the `generate-ci-jobs.py` command line
- Respect endpoint `enabled` flag in `get-endpoints.py`

## Jira
[PERFNFV-313](https://redhat.atlassian.net/browse/PERFNFV-313)

## Depends on
- rickshaw PR #824 (merged)

## Changed files
- **`.github/actions/get-job-parameters/action.yml`** — deprecated runner-type/runner-tags inputs, removed from command line
- **`.github/workflows/endpoint-crucible-ci.yaml`** — removed runner-type and runner-tags from get-job-parameters call
- **`.github/workflows/core-endpoint-crucible-ci.yaml`** — same
- **`.github/actions/get-endpoints/get-endpoints.py`** — respect endpoint enabled flag from crucible-ci.json

## Test plan
- [ ] Verify CI workflows still generate and run jobs correctly
- [ ] Verify previously-broken remotehosts scenarios (cyclictest, oslat, hwnoise) now run

🤖 Generated with [Claude Code](https://claude.com/claude-code)